### PR TITLE
editorTags marked as safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ The class `Article` should be set up like this:
 	use sjaakp\taggable\TaggableBehavior;
 
 	class Article extends ActiveRecord    {
+	
+	public function rules()
+	{
+		return [
+			// ...
+			[['editorTags'], 'safe'],
+		];
+	}
 
     	public function behaviors()
     	{


### PR DESCRIPTION
The field editorTags should be marked as safe in the rules to be processed.
