### PR TITLE
Added table name in the join condition

### DIFF
--- a/TaggableBehavior.php
+++ b/TaggableBehavior.php
@@ -102,7 +102,7 @@ class TaggableBehavior extends Behavior {
          * @var $tc ActiveRecord
          */
         $tc = $this->tagClass;
-        $tpk = current($tc::primaryKey());
+        $tpk = $tc::tableName() . '.' . current($tc::primaryKey());
 
         $tkn = new Expression($owner->getDb()->quoteSql("[[j]].{{{$this->tagKeyAttribute}}}"));
 


### PR DESCRIPTION
Without specifying the table name in join condition, an error is thrown:
SQLSTATE[42702]: Ambiguous column: 7 ERROR: column reference "id" is ambiguous
LINE 1: ...tag".* FROM "tag" INNER JOIN "article_tag" "j" ON "id"="j"."...